### PR TITLE
Allow zendframework/zend-json:^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-json": "~2.5"
+        "zendframework/zend-json": "~2.5 || ^3.0"
     },
     "suggest": {
         "zendframework/zend-http": "Allows use of Zend\\Http\\Client to check version information"


### PR DESCRIPTION
problems with `zend-mvc` when used in console banner, does not allow `zendframework/zend-json:3.0` also should fix https://github.com/zendframework/zend-version/issues/13 and not sure but maybe this https://github.com/zendframework/zend-version/issues/10