### PR TITLE
Updated to php-coveralls/php-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ notifications:
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
@@ -44,4 +44,4 @@ script:
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
 
 after_script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi


### PR DESCRIPTION
With version 2 package has been renamed from `satooshi/php-coveralls` to `php-coveralls/php-coveralls`, and the script has been renamed from `coveralls` to `php-coveralls`